### PR TITLE
add command for exporting keys and cloning with key

### DIFF
--- a/bin/cli.js
+++ b/bin/cli.js
@@ -13,6 +13,7 @@ var config = {
   none: require('../lib/usage'),
   commands: [
     require('../lib/commands/clone'),
+    require('../lib/commands/keys'),
     require('../lib/commands/create'),
     require('../lib/commands/pull'),
     require('../lib/commands/snapshot'),

--- a/lib/commands/clone.js
+++ b/lib/commands/clone.js
@@ -1,6 +1,7 @@
 var fs = require('fs')
 var exit = require('../ui').exitErr
 var download = require('../download')
+var share = require('../share')
 
 module.exports = {
   name: 'clone',
@@ -11,6 +12,11 @@ module.exports = {
 function clone (opts) {
   opts.key = opts._[0]
   if (!opts.key) return exit('key required to clone')
+  var keys = opts.key.split('.')
+  if (keys[1]) {
+    opts.key = keys[0]
+    opts.secretKey = new Buffer(keys[1], 'hex')
+  }
 
   // Force these options for clone command
   opts.resume = false
@@ -23,5 +29,6 @@ function clone (opts) {
   try {
     fs.accessSync(opts.dir, fs.F_OK)
   } catch (e) { fs.mkdirSync(opts.dir) }
-  download('clone', opts)
+  if (opts.secretKey) share('sync', opts)
+  else download('clone', opts)
 }

--- a/lib/commands/keys.js
+++ b/lib/commands/keys.js
@@ -1,0 +1,21 @@
+var Dat = require('dat-node')
+var exit = require('../ui').exitErr
+
+module.exports = {
+  name: 'keys',
+  options: [
+    {
+      name: 'import',
+      boolean: true,
+      default: false
+    }
+  ],
+  command: function (opts) {
+    Dat(opts.dir, opts, function (err, dat) {
+      if (err) return exit(err)
+      if (!opts.import && dat.owner) {
+        process.stdout.write(dat.archive.key.toString('hex') + '.' + dat.archive.metadata.secretKey.toString('hex'))
+      }
+    })
+  }
+}

--- a/lib/commands/sync.js
+++ b/lib/commands/sync.js
@@ -24,6 +24,7 @@ module.exports = {
 
     Dat(opts.dir, opts, function (err, dat) {
       if (err) return exit(err)
+      process.stdout.write('hi')
       if (!dat.owner) return download('sync', opts, dat)
       // TODO: dat.owner is false for snapshot on resume? bug?
       // if (!dat.archive.live) opts.import = false


### PR DESCRIPTION
don't merge this please!

This isn't working. The PR has two parts which aren't necessarily coupled.

1) `dat keys` will export the keys, including the private key. (untested)
2) we could `clone` a dat with the private key too in case we want to be able to write to it.

It doesn't work (I assume because multiwriter isn't implemented!) but I wonder if the api makes sense.

I suspect the only thing that should happen right now would be that `dat key` or `dat status` exports the current public key, perhaps. 