### PR TITLE
add publish!

### DIFF
--- a/bin/cli.js
+++ b/bin/cli.js
@@ -27,10 +27,11 @@ var config = {
   commands: [
     require('../lib/commands/clone'),
     require('../lib/commands/create'),
+    require('../lib/commands/doctor'),
+    require('../lib/commands/publish'),
     require('../lib/commands/pull'),
     require('../lib/commands/snapshot'),
     require('../lib/commands/sync'),
-    require('../lib/commands/doctor'),
     require('../lib/commands/auth/register'),
     require('../lib/commands/auth/whoami'),
     require('../lib/commands/auth/logout'),

--- a/lib/commands/publish.js
+++ b/lib/commands/publish.js
@@ -1,0 +1,60 @@
+var Dat = require('dat-node')
+var prompt = require('prompt')
+var TownshipClient = require('../township')
+var ui = require('../ui')
+
+module.exports = {
+  name: 'publish',
+  options: [],
+  command: publish
+}
+
+function publish (opts) {
+  var client = TownshipClient(opts)
+  if (!client.getLogin().token) return ui.exitErr('Please login before publishing.')
+
+  opts.resume = true // publish must always be a resumed archive
+  Dat(opts.dir, opts, function (err, dat) {
+    if (err && err.indexOf('No existing archive') === -1) return ui.exitErr(err)
+    else if (err) return ui.exitErr('Please create an archive before publishing.')
+
+    var datInfo = {
+      name: dat.meta.name || opts.name,
+      url: dat.meta.url || 'dat://' + dat.key.toString('hex'),
+      title: dat.meta.title,
+      description: dat.meta.description,
+      keywords: dat.meta.keywords
+    }
+
+    if (!datInfo.name) {
+      prompt.message = ''
+      prompt.colors = false
+      prompt.start()
+      prompt.get([{
+        name: 'name',
+        pattern: /^[a-zA-Z\s-]+$/,
+        message: 'Name must be only letters, spaces, or dashes',
+        required: true
+      }], function (err, results) {
+        if (err) return console.log(err.message)
+        datInfo.name = results.name
+
+        // TODO: write name to dat.json?
+        makeRequest()
+      })
+    } else {
+      console.log(`Publishing archive with name "${datInfo.name}" from dat.json.`)
+      makeRequest()
+    }
+
+    function makeRequest () {
+      client.secureRequest({
+        method: 'POST', url: '/dats', body: datInfo, json: true
+      }, function (err, resp, body) {
+        if (err) return ui.exitErr(err)
+        console.log('Successfully published!')
+        process.exit(0)
+      })
+    }
+  })
+}

--- a/tests/helpers/auth-server.js
+++ b/tests/helpers/auth-server.js
@@ -1,6 +1,6 @@
 var path = require('path')
-var Server = require('dat.land/server')
-var initDb = require('dat.land/server/database/init')
+var Server = require('dat-land/server')
+var initDb = require('dat-land/server/database/init')
 var rimraf = require('rimraf')
 
 module.exports = createServer


### PR DESCRIPTION
Replaces old PR #30. 

All set to go!

If you want to test locally, you need to run a datfolderland server:

```
cd dat-next
npm install
npm run auth-server
```

Then you can run auth commands like this:

```
dat-next [cmd] --server http://localhost:8888/api/v1 --config ~/.testrc
```