### PR TITLE
Add metadata progress & Improve Progress updates

### DIFF
--- a/lib/download.js
+++ b/lib/download.js
@@ -114,8 +114,9 @@ module.exports = function (type, opts, dat) {
 
     var st = stats.get()
 
-    progressOutput[2] = (type === 'sync') ? 'Files updated to latest!' : 'Download Finished!'
-    progressOutput[3] = `Total size: ${st.filesTotal} ${st.filesTotal === 1 ? 'file' : 'files'} (${prettyBytes(st.bytesTotal)})`
+    progressOutput[2] = ''
+    progressOutput[3] = (type === 'sync') ? 'Files updated to latest!' : 'Download Finished!'
+    progressOutput[4] = `Total size: ${st.filesTotal} ${st.filesTotal === 1 ? 'file' : 'files'} (${prettyBytes(st.bytesTotal)})`
 
     if (!opts.exit) return true
 

--- a/lib/download.js
+++ b/lib/download.js
@@ -17,16 +17,16 @@ module.exports = function (type, opts, dat) {
   var network = null
   var stats = null
   var archive = null
-  var connected = false
+  var onceConnected = false
   var metadataDownloaded = false
-  var contentPopulated = false
 
   // Logging Init
   var output = [
     [
       'Starting Dat...', // Shows Folder Name
       '', // Shows Link
-      '', // Shows Downloading Progress Bar
+      '', // Shows Metadata Progress Bar
+      '', // Shows Content Progress Bar
       '', // Shows Total Size Info
       '' //  spacer before network info
     ],
@@ -38,6 +38,7 @@ module.exports = function (type, opts, dat) {
   // UI Elements
   var bar = ui.bar()
   var exit = ui.exit(log)
+  var count = 0
 
   // Printing Things!!
   setInterval(function () {
@@ -55,6 +56,11 @@ module.exports = function (type, opts, dat) {
     if (err) return exit(err)
     archive = dat.archive
 
+    archive.open(function () {
+      if (!archive.content) return removeExit() // Not an archive
+      archive.content.once('download-finished', checkDone)
+    })
+
     // General Archive Info
     var niceType = (type === 'clone') ? 'Cloning' : type.charAt(0).toUpperCase() + type.slice(1) + 'ing'
     progressOutput[0] = `${niceType} Dat Archive: ${dat.path}`
@@ -63,51 +69,14 @@ module.exports = function (type, opts, dat) {
 
     // Stats
     stats = dat.trackStats()
-    stats.on('update:blocksProgress', checkDone)
 
     // Network
     network = dat.joinNetwork(opts)
     network.swarm.once('connection', function (peer) {
-      connected = true
+      onceConnected = true
       progressOutput[2] = 'Starting Download...'
-
-      if (archive.metadata.blocksRemaining() === 0) {
-        metadataDownloaded = true
-        archive.metadata.on('update', onMetadataUpdate)
-      }
     })
     progressOutput[2] = 'Looking for Dat Archive in Network'
-
-    // Metadata Download
-    archive.metadata.once('download-finished', function () {
-      metadataDownloaded = true
-
-      // Live metadata updates
-      // TODO: this can be buggy if there are lots of metadata updates
-      archive.metadata.on('update', onMetadataUpdate)
-    })
-
-    // Content is populated
-    // TODO: couldn't get one these to work for all situations
-    // if content.blocks = zero there is no downloads
-    archive.once('content', function () {
-      contentPopulated = true
-    })
-    archive.open(function () {
-      if (!archive.content) return removeExit()
-      archive.content.once('download', function () {
-        contentPopulated = true
-      })
-    })
-
-    function onMetadataUpdate () {
-      if (metadataDownloaded) {
-        metadataDownloaded = false
-        archive.metadata.once('download-finished', function () {
-          metadataDownloaded = true
-        })
-      }
-    }
 
     function removeExit () {
       output[0] = ['']
@@ -119,22 +88,24 @@ module.exports = function (type, opts, dat) {
   }
 
   function updateDownload () {
-    var st = stats.get()
-
-    // TODO: blocksTotal may be slow to populate for large metadata, need to handle that
     // TODO: currently code is buggy for very frequent metadata updates
-    if (!metadataDownloaded || !contentPopulated) {
+    if (archive.metadata.blocksRemaining() > 0) metadataDownloaded = false
+    if (!archive.content) {
       progressOutput[2] = '... Fetching Metadata'
-      progressOutput[3] = ''
       return
     }
-
     // TODO: think about how this could work for empty archives & slow metadata downloads
-    var progress = st.blocksTotal === 0 ? 100 : Math.round(st.blocksProgress * 100 / st.blocksTotal)
-    if (progress === 100 && checkDone()) return
-    progressOutput[2] = bar(progress)
-    if (!connected) progressOutput[3] = 'Waiting for connections to update progress...'
-    else progressOutput[3] = `Total size: ${st.filesTotal} ${st.filesTotal === 1 ? 'file' : 'files'} (${prettyBytes(st.bytesTotal)})`
+    if (checkDone()) return
+    var st = stats.get()
+
+    var metaProgress = archive.metadata.blocks - archive.metadata.blocksRemaining()
+    var metaProgress = Math.round(metaProgress * 100 / archive.metadata.blocks)
+    var contentProgress = st.blocksTotal === 0 ? 100 : Math.round(st.blocksProgress * 100 / st.blocksTotal)
+    progressOutput[2] = 'Metadata: ' + bar(metaProgress) + ' ' + metaProgress + '%'
+    progressOutput[3] = 'Content:  ' + bar(contentProgress) + ' ' + contentProgress + '%'
+
+    if (!onceConnected) progressOutput[4] = 'Waiting for connections to update progress...'
+    else progressOutput[4] = `Total size: ${st.filesTotal} ${st.filesTotal === 1 ? 'file' : 'files'} (${prettyBytes(st.bytesTotal)})`
   }
 
   function updateNetwork () {
@@ -142,10 +113,10 @@ module.exports = function (type, opts, dat) {
   }
 
   function checkDone () {
+    if (!onceConnected || archive.metadata.blocksRemaining() !== 0) return false
+    if (!archive.content || archive.content.blocksRemaining() !== 0) return false
+
     var st = stats.get()
-    if (!connected || !metadataDownloaded || !contentPopulated) return false
-    if (st.blocksTotal !== archive.content.blocks) return false // TODO: hyperdrive-stats bug?
-    if (archive.content.blocksRemaining() !== 0) return false
 
     progressOutput[2] = (type === 'sync') ? 'Files updated to latest!' : 'Download Finished!'
     progressOutput[3] = `Total size: ${st.filesTotal} ${st.filesTotal === 1 ? 'file' : 'files'} (${prettyBytes(st.bytesTotal)})`

--- a/lib/download.js
+++ b/lib/download.js
@@ -18,7 +18,6 @@ module.exports = function (type, opts, dat) {
   var stats = null
   var archive = null
   var onceConnected = false
-  var metadataDownloaded = false
 
   // Logging Init
   var output = [
@@ -38,7 +37,6 @@ module.exports = function (type, opts, dat) {
   // UI Elements
   var bar = ui.bar()
   var exit = ui.exit(log)
-  var count = 0
 
   // Printing Things!!
   setInterval(function () {
@@ -88,8 +86,6 @@ module.exports = function (type, opts, dat) {
   }
 
   function updateDownload () {
-    // TODO: currently code is buggy for very frequent metadata updates
-    if (archive.metadata.blocksRemaining() > 0) metadataDownloaded = false
     if (!archive.content) {
       progressOutput[2] = '... Fetching Metadata'
       return
@@ -98,8 +94,8 @@ module.exports = function (type, opts, dat) {
     if (checkDone()) return
     var st = stats.get()
 
-    var metaProgress = archive.metadata.blocks - archive.metadata.blocksRemaining()
-    var metaProgress = Math.round(metaProgress * 100 / archive.metadata.blocks)
+    var metaBlocksProgress = archive.metadata.blocks - archive.metadata.blocksRemaining()
+    var metaProgress = Math.round(metaBlocksProgress * 100 / archive.metadata.blocks)
     var contentProgress = st.blocksTotal === 0 ? 100 : Math.round(st.blocksProgress * 100 / st.blocksTotal)
     progressOutput[2] = 'Metadata: ' + bar(metaProgress) + ' ' + metaProgress + '%'
     progressOutput[3] = 'Content:  ' + bar(contentProgress) + ' ' + contentProgress + '%'

--- a/lib/ui/import-progress.js
+++ b/lib/ui/import-progress.js
@@ -5,7 +5,7 @@ module.exports = function () {
   return function (importer) {
     if (!importer) return ''
     var importedFiles = importer.fileCount - 1 // TODO: bug in importer?
-    var progress = Math.round(importedFiles * 100 / importer.countStats.files)
-    return bar(progress) + ' ' + importedFiles + ' files imported'
+    var progress = Math.round(importer.bytesImported * 100 / importer.countStats.bytes)
+    return bar(progress) + ' ' + progress + '% ' + importedFiles + ' files imported'
   }
 }


### PR DESCRIPTION
* Adds a progress bar for the metadata. 
* improves the progress stats generally. 

Simplify the progress logic a lot. This definitely works best for the basic share & clone. We may get more edge cases with live updates and sync. But thought it may be better to start simple and fix those as we get them defined.

Also improves the file importing progress, especially for big files. Depends on https://github.com/juliangruber/hyperdrive-import-files/issues/37