### PR TITLE
Sync shortcut

### DIFF
--- a/bin/cli.js
+++ b/bin/cli.js
@@ -1,6 +1,7 @@
 #!/usr/bin/env node
 
 var subcommand = require('subcommand')
+var usage = require('../lib/usage')
 
 process.title = 'dat-next'
 
@@ -24,9 +25,9 @@ var config = {
         abbr: 'v'
       }
     ],
-    command: require('../lib/usage')
+    command: usage
   },
-  none: require('../lib/usage'),
+  none: syncShorthand,
   commands: [
     require('../lib/commands/clone'),
     require('../lib/commands/create'),
@@ -41,7 +42,7 @@ var config = {
     require('../lib/commands/auth/login'),
     {
       name: 'help',
-      command: require('../lib/usage')
+      command: usage
     }
   ],
   aliases: {
@@ -57,4 +58,12 @@ function alias (argv) {
   if (!config.aliases[cmd]) return argv
   argv[0] = config.aliases[cmd]
   return argv
+}
+
+function syncShorthand (opts) {
+  if (!opts._.length) return usage(opts)
+  opts.dir = opts._[0]
+  var sync = require('../lib/commands/sync')
+  opts.import = opts.import || true // TODO: use default opts in sync
+  sync.command(opts)
 }

--- a/tests/sync-owner.js
+++ b/tests/sync-owner.js
@@ -158,6 +158,23 @@ test('sync-owner - port and utp options', function (t) {
   }
 })
 
+test('sync-owner - shorthand', function (t) {
+  var cmd = dat + ' .'
+  var st = spawn(t, cmd, {cwd: fixtures})
+
+  st.stdout.match(function (output) {
+    var sharing = output.indexOf('Sharing latest') > -1
+    if (!sharing) return false
+
+    t.ok(help.matchLink(output), 'prints link')
+
+    st.kill()
+    return true
+  })
+  st.stderr.empty()
+  st.end()
+})
+
 test.onFinish(function () {
   rimraf.sync(path.join(fixtures, '.dat'))
 })

--- a/tests/sync-remote.js
+++ b/tests/sync-remote.js
@@ -7,21 +7,21 @@ var help = require('./helpers')
 var dat = path.resolve(path.join(__dirname, '..', 'bin', 'cli.js'))
 var baseTestDir = help.testFolder()
 var shareDat
+var syncDir
 
 test('sync-remote - default opts', function (t) {
   // cmd: dat sync
   var key
-  var datDir
 
   help.shareFixtures({import: false}, function (_, fixturesDat) {
     shareDat = fixturesDat
     key = shareDat.key.toString('hex')
-    datDir = path.join(baseTestDir, key)
+    syncDir = path.join(baseTestDir, key)
 
     makeClone(function () {
       shareDat.importFiles(function () {
         var cmd = dat + ' sync'
-        var st = spawn(t, cmd, {cwd: datDir})
+        var st = spawn(t, cmd, {cwd: syncDir})
         st.stdout.match(function (output) {
           var updated = output.indexOf('Files updated') > -1
           if (!updated) return false
@@ -58,6 +58,21 @@ test('sync-remote - default opts', function (t) {
     })
     st.stderr.empty()
   }
+})
+
+test('sync-remote - shorthand sync', function (t) {
+  // cmd: dat sync
+  var cmd = dat + ' .'
+  var st = spawn(t, cmd, {cwd: syncDir})
+  st.stdout.match(function (output) {
+    var syncing = output.indexOf('Syncing Dat Archive') > -1
+    if (!syncing) return false
+    t.ok(help.matchLink(output), 'prints link')
+    st.kill()
+    return true
+  })
+  st.stderr.empty()
+  st.end()
 })
 
 test('close sharer', function (t) {


### PR DESCRIPTION
#54 

Makes dat-next backwards compatible, so same shortcut command can be run on **existing** dat folders.