### PR TITLE
Bugs and ui improvements, 2.1.0

### DIFF
--- a/lib/commands/create.js
+++ b/lib/commands/create.js
@@ -13,6 +13,12 @@ module.exports = {
       name: 'import',
       boolean: true,
       default: true
+    },
+    {
+      name: 'ignoreHidden',
+      boolean: true,
+      default: true,
+      abbr: 'ignore-hidden'
     }
   ]
 }
@@ -70,7 +76,12 @@ function create (opts) {
       debug('Importing files into archive')
 
       output[2] = 'Importing files to archive...'
-      importStatus = dat.importFiles(function (err) {
+      importStatus = dat.importFiles({
+        // Can't pass through opts here. opts.live has two meanings (archive.live, live file watching)
+        live: false, // Never live (file watching) for `dat create`
+        resume: false, // Never resume for `dat create`
+        ignoreHidden: opts.ignoreHidden
+      }, function (err) {
         if (err) return exit(err)
         output[2] = opts.live !== false ? 'File import finished!' : 'Snapshot created!'
         output[3] = `Total Size: ${importStatus.fileCount} ${importStatus.fileCount === 1 ? 'file' : 'files'} (${prettyBytes(importStatus.totalSize)})`
@@ -82,6 +93,9 @@ function create (opts) {
         if (dat.key) output[1] = ui.link(dat.key) + '\n'
 
         exit()
+      })
+      importStatus.on('file imported', function (file) {
+        debug(file)
       })
     }
   })

--- a/lib/commands/sync.js
+++ b/lib/commands/sync.js
@@ -11,6 +11,12 @@ module.exports = {
       name: 'import',
       boolean: true,
       default: true
+    },
+    {
+      name: 'ignoreHidden',
+      boolean: true,
+      default: true,
+      abbr: 'ignore-hidden'
     }
   ],
   command: function (opts) {

--- a/lib/download.js
+++ b/lib/download.js
@@ -77,6 +77,7 @@ module.exports = function (type, opts, dat) {
     stats.on('update:blocksProgress', checkDone)
 
     // Network
+    if (!opts.upload && type !== 'sync') opts.upload = false // Do not upload on pull/clone
     network = dat.joinNetwork(opts)
     network.swarm.once('connection', function (peer) {
       debug('Network: first peer connected')

--- a/lib/download.js
+++ b/lib/download.js
@@ -106,7 +106,7 @@ module.exports = function (type, opts, dat) {
 
     var metaBlocksProgress = archive.metadata.blocks - archive.metadata.blocksRemaining()
     var metaProgress = Math.round(metaBlocksProgress * 100 / archive.metadata.blocks)
-    var contentProgress = st.blocksTotal === 0 ? 100 : Math.round(st.blocksProgress * 100 / st.blocksTotal)
+    var contentProgress = st.blocksTotal === 0 ? 0 : Math.round(st.blocksProgress * 100 / st.blocksTotal)
     progressOutput[2] = 'Metadata: ' + bar(metaProgress) + ' ' + metaProgress + '%'
     progressOutput[3] = 'Content:  ' + bar(contentProgress) + ' ' + contentProgress + '%'
 

--- a/lib/share.js
+++ b/lib/share.js
@@ -68,8 +68,11 @@ module.exports = function sync (type, opts, dat) {
       // File Imports
       progressOutput[2] = 'Importing new & updated files to archive...'
 
-      // TODO: allow live: true
-      importStatus = dat.importFiles({live: false, resume: true}, function (err) {
+      importStatus = dat.importFiles({
+        live: false, // TODO: allow live: true. opts.live is used by archive.live though =(
+        resume: true,
+        ignoreHidden: opts.ignoreHidden
+      }, function (err) {
         if (err) return exit(err)
         debug('Import finished')
         importDone = true

--- a/lib/ui/import-progress.js
+++ b/lib/ui/import-progress.js
@@ -4,8 +4,10 @@ module.exports = function () {
   var bar = Bar()
   return function (importer) {
     if (!importer) return ''
-    var importedFiles = importer.fileCount - 1 // TODO: bug in importer?
-    var progress = Math.round(importedFiles * 100 / importer.countStats.files)
-    return bar(progress) + ' ' + importedFiles + ' files imported'
+    var importedBytes = importer.bytesImported
+    var importedFiles = importer.fileCount - 1 // Importer counts files before importing
+    if (importedFiles > 1) importedFiles = importedFiles - 1 // Do not count dat.json
+    var progress = Math.round(importedBytes * 100 / importer.countStats.bytes)
+    return bar(progress) + ` ${importedFiles} ${importedFiles === 1 ? 'file' : 'files'} imported`
   }
 }

--- a/package.json
+++ b/package.json
@@ -21,8 +21,8 @@
   "homepage": "https://github.com/joehand/dat-next#readme",
   "dependencies": {
     "dat-doctor": "^1.0.1",
-    "dat-node": "^1.0.0",
     "dat-encoding": "^4.0.1",
+    "dat-node": "^1.1.1",
     "debug": "^2.4.5",
     "hyperdrive": "^7.12.2",
     "hyperdrive-network-speed": "^1.1.0",

--- a/package.json
+++ b/package.json
@@ -25,6 +25,7 @@
     "dat-node": "^1.1.1",
     "debug": "^2.4.5",
     "hyperdrive": "^7.12.2",
+    "hyperdrive-count-import": "^1.0.2",
     "hyperdrive-network-speed": "^1.1.0",
     "memdb": "^1.3.1",
     "nets": "^3.2.0",

--- a/package.json
+++ b/package.json
@@ -24,6 +24,8 @@
     "dat-node": "^1.0.0",
     "dat-encoding": "^4.0.1",
     "debug": "^2.4.5",
+    "hyperdrive": "^7.12.2",
+    "hyperdrive-network-speed": "^1.1.0",
     "memdb": "^1.3.1",
     "nets": "^3.2.0",
     "pretty-bytes": "^4.0.2",

--- a/tests/clone.js
+++ b/tests/clone.js
@@ -62,7 +62,6 @@ test('clone - errors on existing dir', function (t) {
     st.kill()
     return true
   })
-  st.stdout.empty()
   st.end()
 })
 

--- a/tests/sync-owner.js
+++ b/tests/sync-owner.js
@@ -125,6 +125,60 @@ test('sync-owner - imports after no-import create', function (t) {
   st.end()
 })
 
+test('sync-owner - turn off ignore hidden', function (t) {
+  // cmd: dat sync
+  var hiddenFile = path.join(fixtures, '.hidden-file')
+  var cmd = dat + ' sync --no-ignore-hidden'
+  fs.writeFile(hiddenFile, 'You cannot see me', function(err) {
+    t.error(err)
+
+    var st = spawn(t, cmd, {cwd: fixtures, end: false})
+    var key
+
+    st.stdout.match(function (output) {
+      var sharing = output.indexOf('Dat Network') > -1
+      if (!sharing) return false
+
+      key = help.matchLink(output)
+
+      downloadDat()
+      return true
+    })
+    st.stderr.empty()
+    st.end()
+
+    function downloadDat () {
+      var downloadDir = path.join(help.testFolder(), '' + Date.now())
+      mkdirp.sync(downloadDir)
+
+      Dat(downloadDir, { key: key }, function (err, tmpDat) {
+        if (err) throw err
+
+        downDat = tmpDat
+        downDat.joinNetwork()
+
+        downDat.network.swarm.once('connection', function () {
+          downDat.archive.list({live: false}, function (err, data) {
+            var hasHiddenFile = data.filter(function (entry) {
+              return entry.name === '.hidden-file'
+            })
+            t.ok(hasHiddenFile.length, 'hidden file in archive')
+            downDat.network.swarm.close(function () {
+              downDat.close(function () {
+                rimraf(downDat.path, function () {
+                  fs.unlink(hiddenFile, function () {
+                    t.end()
+                  })
+                })
+              })
+            })
+          })
+        })
+      })
+    }
+  })
+})
+
 test('sync-owner - port and utp options', function (t) {
   var port = 3281
   var cmd = dat + ' sync --port ' + port + ' --no-utp'

--- a/tests/sync-owner.js
+++ b/tests/sync-owner.js
@@ -129,7 +129,7 @@ test('sync-owner - turn off ignore hidden', function (t) {
   // cmd: dat sync
   var hiddenFile = path.join(fixtures, '.hidden-file')
   var cmd = dat + ' sync --no-ignore-hidden'
-  fs.writeFile(hiddenFile, 'You cannot see me', function(err) {
+  fs.writeFile(hiddenFile, 'You cannot see me', function (err) {
     t.error(err)
 
     var st = spawn(t, cmd, {cwd: fixtures, end: false})
@@ -159,6 +159,7 @@ test('sync-owner - turn off ignore hidden', function (t) {
 
         downDat.network.swarm.once('connection', function () {
           downDat.archive.list({live: false}, function (err, data) {
+            t.error(err)
             var hasHiddenFile = data.filter(function (entry) {
               return entry.name === '.hidden-file'
             })


### PR DESCRIPTION
* Include metadata in download/upload speed
* Use bytes instead of files for import progress - this makes it easier to see when big files are being imported & is more accurate
* Add `--ignore-hidden` option as true by default (`--no-ignore-hidden` to import hidden files)
* Fix content progress showing incorrectly on big metadata (https://github.com/joehand/dat-next/issues/68)
* Do not upload data for clone & pull