### PR TITLE
Backwards compatibility & shortcut command changes

### DIFF
--- a/bin/cli.js
+++ b/bin/cli.js
@@ -1,8 +1,8 @@
 #!/usr/bin/env node
 
-var subcommand = require('subcommand')
 var fs = require('fs')
 var mkdirp = require('mkdirp')
+var subcommand = require('subcommand')
 var encoding = require('dat-encoding')
 var debug = require('debug')('dat')
 var usage = require('../lib/usage')

--- a/bin/cli.js
+++ b/bin/cli.js
@@ -68,7 +68,7 @@ function alias (argv) {
 }
 
 function syncShorthand (opts) {
-  if (!opts._.length) return done ()
+  if (!opts._.length) return done()
   debug('Sync shortcut command')
   debug(opts)
 
@@ -84,7 +84,7 @@ function syncShorthand (opts) {
       mkdirp(opts.dir, function () {
         require('../lib/download')('sync', opts)
       })
-    } catch (e) { return done ()}
+    } catch (e) { return done() }
   } else {
     try {
       debug('Share sync')
@@ -96,7 +96,7 @@ function syncShorthand (opts) {
         opts.import = opts.import || true // TODO: use default opts in sync
         sync.command(opts)
       })
-    } catch (e) { return done ()}
+    } catch (e) { return done() }
   }
 
   function done () {

--- a/bin/cli.js
+++ b/bin/cli.js
@@ -73,7 +73,7 @@ function syncShorthand (opts) {
   debug(opts)
 
   if (opts._.length > 1) {
-    // dat <link> {dir}
+    // dat <link> {dir} - clone/resume <link> in {dir}
     try {
       debug('Clone sync')
       opts.key = encoding.toStr(opts._[0])
@@ -86,15 +86,17 @@ function syncShorthand (opts) {
       })
     } catch (e) { return done() }
   } else {
+    // dat {dir} - sync existing dat in {dir}
     try {
       debug('Share sync')
       opts.dir = opts._[0]
       fs.stat(opts.dir, function (err, stat) {
         if (err || !stat.isDirectory()) return usage(opts)
 
-        var sync = require('../lib/commands/sync')
-        opts.import = opts.import || true // TODO: use default opts in sync
-        sync.command(opts)
+        // Set default opts. TODO: use default opts in sync
+        opts.watch = opts.watch || true
+        opts.import = opts.import || true
+        require('../lib/commands/sync').command(opts)
       })
     } catch (e) { return done() }
   }

--- a/lib/commands/create.js
+++ b/lib/commands/create.js
@@ -31,7 +31,7 @@ module.exports = {
 
 function create (opts) {
   opts.resume = false // cannot resume for create
-  if (opts._.length) opts.dir = opts._[0]
+  if (opts._.length && opts.dir === process.cwd()) opts.dir = opts._[0] // use first arg as dir if default set
 
   var importStatus = null
 

--- a/lib/commands/pull.js
+++ b/lib/commands/pull.js
@@ -19,6 +19,8 @@ module.exports = {
     }
   ],
   command: function (opts) {
+    if (opts._.length && opts.dir === process.cwd()) opts.dir = opts._[0] // use first arg as dir if default set
+
     // Force these options for pull command
     opts.resume = true
     opts.exit = true

--- a/lib/commands/share.js
+++ b/lib/commands/share.js
@@ -32,6 +32,8 @@ module.exports = {
     }
   ],
   command: function (opts) {
+    if (opts._.length && opts.dir === process.cwd()) opts.dir = opts._[0] // use first arg as dir if default set
+
     // Gets overwritten by logger.
     // Logging starts after Dat cb for lib/download sync
     // So we need this to show something right away

--- a/lib/commands/snapshot.js
+++ b/lib/commands/snapshot.js
@@ -10,6 +10,8 @@ module.exports = {
   ].join('\n'),
   options: [],
   command: function snapshot (opts) {
+    if (opts._.length && opts.dir === process.cwd()) opts.dir = opts._[0] // use first arg as dir if default set
+
     // Force these options for snapshot command
     opts.resume = false
     opts.live = false

--- a/lib/commands/sync.js
+++ b/lib/commands/sync.js
@@ -33,6 +33,8 @@ module.exports = {
     }
   ],
   command: function (opts) {
+    if (opts._.length && opts.dir === process.cwd()) opts.dir = opts._[0] // use first arg as dir if default set
+
     // Gets overwritten by logger.
     // Logging starts after Dat cb for lib/download sync
     // So we need this to show something right away

--- a/package.json
+++ b/package.json
@@ -25,6 +25,7 @@
     "dat-node": "^1.2.3",
     "debug": "^2.4.5",
     "memdb": "^1.3.1",
+    "mkdirp": "^0.5.1",
     "nets": "^3.2.0",
     "pretty-bytes": "^4.0.2",
     "progress-string": "^1.2.1",

--- a/readme.md
+++ b/readme.md
@@ -171,16 +171,16 @@ You can also do `create` and `sync` in separate steps if you'd like more control
 #### Creating a Dat archive
 
 ```
-dat create [--dir=<folder>] [--no-import]
+dat create [<folder>] [--no-import]
 ```
 
-Create a new Dat Archive in the current directory (or specify `--dir`).
+Create a new Dat Archive in the current directory (or specify `dir`).
 Will automatically import the files in that directory to the archive.
 
 #### Syncing to Network
 
 ```
-dat sync [--dir=<folder>] [--no-import] [--no-watch]
+dat sync [<folder>] [--no-import] [--no-watch]
 ```
 
 Start sharing your Dat Archive over the network.
@@ -193,7 +193,7 @@ Sync watched files for changes and imports updated files.
 #### Snapshot
 
 ```
-dat snapshot [--dir=<folder>]
+dat snapshot [<folder>]
 ```
 
 Snapshot will create the archive in snapshot, `{live: false}`, mode.
@@ -217,16 +217,21 @@ Will create a folder with the key name is no folder is specified.
 Once a Dat is clone, you can run either `dat pull` or `dat sync` in the folder to update the archive.
 
 ```
-dat pull [--dir=<folder>]
+dat pull [<folder>]
 ```
 
 Update a cloned Dat Archive to latest files and exit.
 
 ```
-dat sync [--dir=<folder>]
+dat sync [<folder>]
 ```
 
 Download latest files and keep connection open to continue updating as remote source is updated.
+
+### Shortcut commands
+
+* `dat <link> {dir}` will run `dat clone` for new dats or resume the exiting dat in `dir`
+* `dat {dir}` is the same as running `dat sync {dir}`
 
 ### Dat Registry and Authentication
 

--- a/tests/clone.js
+++ b/tests/clone.js
@@ -231,6 +231,45 @@ test('clone - invalid link', function (t) {
   st.end()
 })
 
+test('clone - stateless clone `dat <link> {dir}`', function (t) {
+  var key = shareDat.key.toString('hex')
+  var customDir = 'stateless-dir'
+  var cmd = dat + ' ' + key + ' ' + customDir
+  var st = spawn(t, cmd, {cwd: baseTestDir})
+  st.stdout.match(function (output) {
+    var downloadFinished = output.indexOf('Files updated to latest') > -1
+    if (!downloadFinished) return false
+
+    t.ok(output.indexOf('dat-download-folder/' + customDir) > -1, 'prints dir')
+    t.ok(help.isDir(path.join(baseTestDir, customDir)), 'creates download directory')
+
+    st.kill()
+    return true
+  })
+  st.stderr.empty()
+  st.end()
+})
+
+test('clone - resume stateless clone `dat <link> {dir}`', function (t) {
+  // same thing as above, with existing dir
+  var key = shareDat.key.toString('hex')
+  var customDir = 'stateless-dir'
+  var cmd = dat + ' ' + key + ' ' + customDir
+  var st = spawn(t, cmd, {cwd: baseTestDir})
+  st.stdout.match(function (output) {
+    var downloadFinished = output.indexOf('Files updated to latest') > -1
+    if (!downloadFinished) return false
+
+    t.ok(output.indexOf('dat-download-folder/' + customDir) > -1, 'prints dir')
+    t.ok(help.isDir(path.join(baseTestDir, customDir)), 'creates download directory')
+
+    st.kill()
+    return true
+  })
+  st.stderr.empty()
+  st.end()
+})
+
 test('close sharer', function (t) {
   shareDat.close(function () {
     rimraf.sync(path.join(shareDat.path, '.dat'))

--- a/tests/pull.js
+++ b/tests/pull.js
@@ -85,7 +85,6 @@ test('pull - default opts', function (t) {
   })
 })
 
-
 test('pull - with dir arg', function (t) {
   var dirName = shareKey
   var datDir = path.join(baseTestDir, shareKey)

--- a/tests/pull.js
+++ b/tests/pull.js
@@ -85,6 +85,27 @@ test('pull - default opts', function (t) {
   })
 })
 
+
+test('pull - with dir arg', function (t) {
+  var dirName = shareKey
+  var datDir = path.join(baseTestDir, shareKey)
+  var cmd = dat + ' pull ' + dirName
+  var st = spawn(t, cmd, {cwd: baseTestDir})
+  st.stdout.match(function (output) {
+    var downloadFinished = output.indexOf('Download Finished') > -1
+    if (!downloadFinished) return false
+
+    t.ok(output.indexOf('dat-download-folder/' + dirName) > -1, 'prints dir')
+    t.ok(help.isDir(datDir), 'creates download directory')
+
+    st.kill()
+    return true
+  })
+  st.succeeds('exits after finishing download')
+  st.stderr.empty()
+  st.end()
+})
+
 test('close sharer', function (t) {
   shareDat.close(function () {
     rimraf.sync(path.join(shareDat.path, '.dat'))

--- a/tests/share.js
+++ b/tests/share.js
@@ -34,6 +34,25 @@ test('share - default opts', function (t) {
   st.end()
 })
 
+test('share - with dir arg', function (t) {
+  rimraf.sync(path.join(fixtures, '.dat'))
+  var cmd = dat + ' share ' + fixtures
+  var st = spawn(t, cmd)
+
+  st.stdout.match(function (output) {
+    var importFinished = output.indexOf('Total Size') > -1
+    if (!importFinished) return false
+
+    t.ok(help.isDir(path.join(fixtures, '.dat')), 'creates dat directory')
+    t.ok(output.indexOf('Looking for connections') > -1, 'network')
+
+    st.kill()
+    return true
+  })
+  st.stderr.empty()
+  st.end()
+})
+
 test.onFinish(function () {
   rimraf.sync(path.join(fixtures, '.dat'))
 })

--- a/tests/sync-owner.js
+++ b/tests/sync-owner.js
@@ -230,6 +230,23 @@ test('sync-owner - shorthand', function (t) {
   st.end()
 })
 
+test('sync-owner - dir argument', function (t) {
+  var cmd = dat + ' sync ' + fixtures
+  var st = spawn(t, cmd)
+
+  st.stdout.match(function (output) {
+    var sharing = output.indexOf('Looking for connections') > -1
+    if (!sharing) return false
+
+    t.ok(help.matchLink(output), 'prints link')
+
+    st.kill()
+    return true
+  })
+  st.stderr.empty()
+  st.end()
+})
+
 if (!process.env.TRAVIS) {
   test('sync-owner - live', function (t) {
     var liveFile = path.join(fixtures, 'live.txt')

--- a/tests/sync-remote.js
+++ b/tests/sync-remote.js
@@ -89,7 +89,6 @@ test('sync-remote - dir arg', function (t) {
   st.end()
 })
 
-
 test('close sharer', function (t) {
   shareDat.close(function () {
     rimraf.sync(path.join(shareDat.path, '.dat'))

--- a/tests/sync-remote.js
+++ b/tests/sync-remote.js
@@ -75,6 +75,21 @@ test('sync-remote - shorthand sync', function (t) {
   st.end()
 })
 
+test('sync-remote - dir arg', function (t) {
+  var cmd = dat + ' ' + syncDir
+  var st = spawn(t, cmd)
+  st.stdout.match(function (output) {
+    var syncing = output.indexOf('Syncing Dat Archive') > -1
+    if (!syncing) return false
+    t.ok(help.matchLink(output), 'prints link')
+    st.kill()
+    return true
+  })
+  st.stderr.empty()
+  st.end()
+})
+
+
 test('close sharer', function (t) {
   shareDat.close(function () {
     rimraf.sync(path.join(shareDat.path, '.dat'))


### PR DESCRIPTION
* `dat <link> {dir}` - stateless clone/sync command, #91 
* `dat {cmd} dir` - dir as third arg for most commands, #90 


TODO: 

- [x] update existing tests for dir args
- [x] add new test for stateless clone command
- [x] decide if mkdirp should happen
- [x] documentation on new command & args