### PR TITLE
url in dat.json should always be right when publishing

### DIFF
--- a/lib/commands/publish.js
+++ b/lib/commands/publish.js
@@ -27,11 +27,9 @@ function publish (opts) {
     })
 
     function publish (dat) {
-      var key = encoding.toStr(dat.key)
-      if (key !== encoding.toStr(dat.meta.url)) dat.meta.url = 'dat://' + key
       var datInfo = {
         name: dat.meta.name || opts.name,
-        url: dat.meta.url,
+        url: 'dat://' + encoding.toStr(dat.key),
         title: dat.meta.title,
         description: dat.meta.description,
         keywords: dat.meta.keywords

--- a/lib/commands/publish.js
+++ b/lib/commands/publish.js
@@ -1,4 +1,5 @@
 var Dat = require('dat-node')
+var encoding = require('dat-encoding')
 var prompt = require('prompt')
 var TownshipClient = require('../township')
 var ui = require('../ui')
@@ -26,9 +27,11 @@ function publish (opts) {
     })
 
     function publish (dat) {
+      var key = encoding.toStr(dat.key)
+      if (key !== encoding.toStr(dat.meta.url)) dat.meta.url = 'dat://' + key
       var datInfo = {
         name: dat.meta.name || opts.name,
-        url: dat.meta.url || 'dat://' + dat.key.toString('hex'),
+        url: dat.meta.url,
         title: dat.meta.title,
         description: dat.meta.description,
         keywords: dat.meta.keywords

--- a/tests/auth.js
+++ b/tests/auth.js
@@ -103,6 +103,29 @@ authServer(port, function (err, server, closeServer) {
     st.end()
   })
 
+  test('auth - publish our awesome dat with bad dat.json url', function (t) {
+    fs.readFile(path.join(fixtures, 'dat.json'), function (err, contents) {
+      t.ifError(err)
+      var info = JSON.parse(contents)
+      var oldUrl = info.url
+      info.url = info.url.replace('e','a')
+      fs.writeFile(path.join(fixtures, 'dat.json'), JSON.stringify(info), function (err) {
+        t.ifError(err, 'error after write')
+        var cmd = dat + ' publish --name awesome'
+        var st = spawn(t, cmd, {cwd: fixtures})
+        st.stdout.match(function (output) {
+          var published = output.indexOf('Successfully published') > -1
+          if (!published) return false
+          t.ok(published, 'published')
+          t.same(help.datJson(fixtures).url, oldUrl, 'has dat.json with url')
+          return true
+        })
+        st.stderr.empty()
+        st.end()
+      })
+    })
+  })
+
   test('auth - clone from registry', function (t) {
     // MAKE SURE THESE MATCH WHAT is published above
     // TODO: be less lazy and make a publish helper

--- a/tests/auth.js
+++ b/tests/auth.js
@@ -108,7 +108,7 @@ authServer(port, function (err, server, closeServer) {
       t.ifError(err)
       var info = JSON.parse(contents)
       var oldUrl = info.url
-      info.url = info.url.replace('e','a')
+      info.url = info.url.replace('e', 'a')
       fs.writeFile(path.join(fixtures, 'dat.json'), JSON.stringify(info), function (err) {
         t.ifError(err, 'error after write')
         var cmd = dat + ' publish --name awesome'


### PR DESCRIPTION
This makes sure that stale dat.json files aren't preventing people from publishing their dat