### PR TITLE
Ensure module-wide 'dat' reference is set.

### DIFF
--- a/lib/download.js
+++ b/lib/download.js
@@ -52,8 +52,10 @@ module.exports = function (type, opts, dat) {
   if (!dat) Dat(opts.dir, opts, start)
   else start(null, dat)
 
-  function start (err, dat) {
+  function start (err, theDat) {
     if (err) return exit(err)
+
+    dat = theDat
 
     debug('Download: ' + type + ' on ' + dat.key.toString('hex'))
 


### PR DESCRIPTION
This is necessary, since line 118 references the module-wide 'dat'
reference, and there are two entry-points for the 'start' function.

cc @maxogden @mafintosh