### PR TITLE
check key with dat.key, bug fix from dat-node 1.3.2

### DIFF
--- a/lib/download.js
+++ b/lib/download.js
@@ -13,7 +13,8 @@ module.exports = function (type, opts, dat) {
 
   // TODO: clean up this logic
   var resume = opts.resume || false
-  if (!opts.key && !resume) return ui.exit()('lib/download Key required to download')
+  var hasKey = dat && dat.key || opts.key
+  if (!hasKey && !resume) return ui.exit()('lib/download Key required to download')
 
   var network = null
   var stats = null


### PR DESCRIPTION
I was relying on the mutated options to check for key. dat-node 1.3.2 fixed that bug so we can't rely on it anymore =).

